### PR TITLE
Update readme-qt.rst

### DIFF
--- a/doc/readme-qt.rst
+++ b/doc/readme-qt.rst
@@ -21,7 +21,7 @@ then execute the following:
 
 ::
 
-    qmake
+    qmake "USE_UPNP=-"
     make
 
 Alternatively, install Qt Creator and open the `blackcoin-qt.pro` file.


### PR DESCRIPTION
In documentation added the option "USE_UPNP=-" which disables UPNP. Otherwise the compilation exits with the error because miniupnpc is required but not installed. Tested following the readme instructions from clean kubuntu14.04 install. 
I know that UPNP support is recommended but this is explained further down in documentation so the user can enable it if he wishes. It is more important for new users to be able to compile without errors out of the box following the instructions.
