### PR TITLE
rpccall: rewindchain

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2403,32 +2403,37 @@ static filesystem::path BlockFilePath(unsigned int nFile)
     return GetDataDir() / strBlockFn;
 }
 
-FILE* OpenBlockFile(unsigned int nFile, unsigned int nBlockPos, const char* pszMode)
+static unsigned int nCurrentBlockFile = 1;
+
+FILE* OpenBlockFile(bool fHeaderFile, unsigned int nFile, unsigned int nBlockPos, const char* pszMode)
 {
     if ((nFile < 1) || (nFile == (unsigned int) -1))
         return NULL;
-    FILE* file = fopen(BlockFilePath(nFile).string().c_str(), pszMode);
+    
+    string strBlockFn = strprintf(fHeaderFile ? "blk_hdr%04u.dat": "blk%04u.dat", nFile);
+    FILE* file = fopen((GetDataDir() / strBlockFn).string().c_str(), pszMode);
     if (!file)
         return NULL;
+    
     if (nBlockPos != 0 && !strchr(pszMode, 'a') && !strchr(pszMode, 'w'))
     {
         if (fseek(file, nBlockPos, SEEK_SET) != 0)
         {
             fclose(file);
             return NULL;
-        }
-    }
+        };
+    };
     return file;
 }
 
-static unsigned int nCurrentBlockFile = 1;
-
-FILE* AppendBlockFile(unsigned int& nFileRet)
+FILE* AppendBlockFile(bool fHeaderFile, unsigned int& nFileRet, const char* fmode)
 {
     nFileRet = 0;
     while (true)
     {
-        FILE* file = OpenBlockFile(nCurrentBlockFile, 0, "ab");
+        FILE* file = OpenBlockFile(fHeaderFile, nCurrentBlockFile,
+            0, fmode);
+        
         if (!file)
             return NULL;
         if (fseek(file, 0, SEEK_END) != 0)
@@ -2438,10 +2443,11 @@ FILE* AppendBlockFile(unsigned int& nFileRet)
         {
             nFileRet = nCurrentBlockFile;
             return file;
-        }
+        };
+        
         fclose(file);
         nCurrentBlockFile++;
-    }
+    };
 }
 
 bool LoadBlockIndex(bool fAllowNew)

--- a/src/main.h
+++ b/src/main.h
@@ -123,8 +123,8 @@ void PushGetBlocks(CNode* pnode, CBlockIndex* pindexBegin, uint256 hashEnd);
 
 bool ProcessBlock(CNode* pfrom, CBlock* pblock);
 bool CheckDiskSpace(uint64_t nAdditionalBytes=0);
-FILE* OpenBlockFile(unsigned int nFile, unsigned int nBlockPos, const char* pszMode="rb");
-FILE* AppendBlockFile(unsigned int& nFileRet);
+FILE* OpenBlockFile(bool fHeaderFile, unsigned int nFile, unsigned int nBlockPos, const char* pszMode="rb");
+FILE* AppendBlockFile(bool fHeaderFile, unsigned int& nFileRet, const char* fmode = "ab");
 bool LoadBlockIndex(bool fAllowNew=true);
 void PrintBlockTree();
 CBlockIndex* FindBlockByHeight(int nHeight);
@@ -310,8 +310,7 @@ public:
 
     bool ReadFromDisk(CDiskTxPos pos, FILE** pfileRet=NULL)
     {
-        CAutoFile filein = CAutoFile(OpenBlockFile(pos.nFile, 0, pfileRet ? "rb+" : "rb"), SER_DISK, CLIENT_VERSION);
-        if (!filein)
+        CAutoFile filein = CAutoFile(OpenBlockFile(false, pos.nFile, 0, pfileRet ? "rb+" : "rb"), SER_DISK, CLIENT_VERSION); if (!filein) 
             return error("CTransaction::ReadFromDisk() : OpenBlockFile failed");
 
         // Read transaction
@@ -757,7 +756,7 @@ public:
     bool WriteToDisk(unsigned int& nFileRet, unsigned int& nBlockPosRet)
     {
         // Open history file to append
-        CAutoFile fileout = CAutoFile(AppendBlockFile(nFileRet), SER_DISK, CLIENT_VERSION);
+        CAutoFile fileout = CAutoFile(AppendBlockFile(false, nFileRet), SER_DISK, CLIENT_VERSION);
         if (!fileout)
             return error("CBlock::WriteToDisk() : AppendBlockFile failed");
 
@@ -785,7 +784,7 @@ public:
         SetNull();
 
         // Open history file to read
-        CAutoFile filein = CAutoFile(OpenBlockFile(nFile, nBlockPos, "rb"), SER_DISK, CLIENT_VERSION);
+        CAutoFile filein = CAutoFile(OpenBlockFile(false, nFile, nBlockPos, "rb"), SER_DISK, CLIENT_VERSION);
         if (!filein)
             return error("CBlock::ReadFromDisk() : OpenBlockFile failed");
         if (!fReadTransactions)

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -7,6 +7,9 @@
 #include "main.h"
 #include "kernel.h"
 #include "checkpoints.h"
+#include "init.h"
+#include "txdb.h"
+#include <errno.h>
 
 using namespace json_spirit;
 using namespace std;
@@ -272,6 +275,221 @@ Value getblockbynumber(const Array& params, bool fHelp)
     block.ReadFromDisk(pblockindex, true);
 
     return blockToJSON(block, pblockindex, params.size() > 1 ? params[1].get_bool() : false);
+}
+
+Value rewindchain(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() < 1 || params.size() > 2)
+        throw runtime_error(
+            "rewindchain <number>\n"
+            "Remove <number> blocks from the chain.");
+
+    int nNumber = params[0].get_int();
+    if (nNumber < 0 || nNumber > nBestHeight)
+        throw runtime_error("Block number out of range.");
+    
+    
+    Object result;
+    int nRemoved = 0;
+    
+    {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+    
+    
+    uint32_t nFileRet = 0;
+    
+    uint8_t buffer[512];
+    
+    LogPrintf("rewindchain %d\n", nNumber);
+    
+    void* nFind;
+    
+    for (int i = 0; i < nNumber; ++i)
+    {
+        memset(buffer, 0, sizeof(buffer));
+        
+        FILE* fp = AppendBlockFile(false, nFileRet, "r+b");
+        if (!fp)
+        {
+            LogPrintf("AppendBlockFile failed.\n");
+            break;
+        };
+        
+        errno = 0;
+        if (fseek(fp, 0, SEEK_END) != 0)
+        {
+            LogPrintf("fseek failed: %s\n", strerror(errno));
+            break;
+        };
+        
+        long int fpos = ftell(fp);
+        
+        if (fpos == -1)
+        {
+            LogPrintf("ftell failed: %s\n", strerror(errno));
+            break;
+        };
+        
+        long int foundPos = -1;
+        long int readSize = sizeof(buffer) / 2;
+        while (fpos > 0)
+        {
+            if (fpos < (long int)sizeof(buffer) / 2)
+                readSize = fpos;
+            
+            memcpy(buffer+readSize, buffer, readSize); // move last read data (incase token crosses a boundary) 
+            fpos -= readSize;
+            
+            if (fseek(fp, fpos, SEEK_SET) != 0)
+            {
+                LogPrintf("fseek failed: %s\n", strerror(errno));
+                break;
+            };
+            
+            errno = 0;
+            if (fread(buffer, sizeof(uint8_t), readSize, fp) != (size_t)readSize)
+            {
+                if (errno != 0)
+                    LogPrintf("fread failed: %s\n", strerror(errno));
+                else
+                    LogPrintf("End of file.\n");
+                break;
+            };
+            
+            uint32_t findPos = sizeof(buffer);
+            while (findPos > MESSAGE_START_SIZE)
+            {
+                if ((nFind = bcblk::memrchr(buffer, Params().MessageStart()[0], findPos-MESSAGE_START_SIZE))) 
+                {
+                    if (memcmp(nFind, Params().MessageStart(), MESSAGE_START_SIZE) == 0)
+                    {
+                        foundPos = ((uint8_t*)nFind - buffer) + MESSAGE_START_SIZE;
+                        break;
+                    } else
+                    {
+                        findPos = ((uint8_t*)nFind - buffer);
+                        // -- step over matched char that wasn't pchMessageStart
+                        if (findPos > 0) // prevent findPos < 0 (unsigned)
+                            findPos--;
+                    };
+                } else
+                {
+                    break; // pchMessageStart[0] not found in buffer 
+                };
+            };
+            
+            if (foundPos > -1)
+                break;
+        };
+        
+        LogPrintf("fpos %d, foundPos %d.\n", fpos, foundPos);
+        
+        if (foundPos < 0)
+        {
+            LogPrintf("block start not found.\n");
+            fclose(fp);
+            break;
+        };
+        
+        CAutoFile blkdat(fp, SER_DISK, CLIENT_VERSION);
+        
+        if (fseek(blkdat, fpos+foundPos, SEEK_SET) != 0)
+        {
+            LogPrintf("fseek blkdat failed: %s\n", strerror(errno));
+            break;
+        };
+        
+        unsigned int nSize;
+        blkdat >> nSize;
+        LogPrintf("nSize %u .\n", nSize);
+        
+        if (nSize < 1 || nSize > MAX_BLOCK_SIZE)
+        {
+            LogPrintf("block size error %u\n", nSize);
+            
+        };
+    
+        CBlock block;
+        blkdat >> block;
+        uint256 hashblock = block.GetHash();
+        LogPrintf("hashblock %s .\n", hashblock.ToString().c_str());
+        
+        std::map<uint256, CBlockIndex*>::iterator mi = mapBlockIndex.find(hashblock);
+        if (mi != mapBlockIndex.end() && (*mi).second)
+        {
+            LogPrintf("block is in main chain.\n");
+            
+            if (!mi->second->pprev)
+            {
+                LogPrintf("! mi->second.pprev\n");
+            } else
+            {
+                {
+                    CBlock blockPrev; // strange way SetBestChain works, TODO: does it need the full block?
+                    if (!blockPrev.ReadFromDisk(mi->second->pprev))
+                    {
+                        LogPrintf("blockPrev.ReadFromDisk failed %s.\n", mi->second->pprev->GetBlockHash().ToString().c_str());
+                        break;
+                    };
+                    
+                    CTxDB txdb;
+                    if (!blockPrev.SetBestChain(txdb, mi->second->pprev))
+                    {
+                        LogPrintf("SetBestChain failed.\n");
+                    };
+                }
+                mi->second->pprev->pnext = NULL;
+            };
+            
+            delete mi->second;
+            mapBlockIndex.erase(mi);
+        };
+
+        std::map<uint256, COrphanBlock*>::iterator miOph = mapOrphanBlocks.find(hashblock);
+        if (miOph != mapOrphanBlocks.end())
+        {
+            LogPrintf("block is an orphan.\n");
+            mapOrphanBlocks.erase(miOph);
+        };
+        
+        CTxDB txdb;
+        for (vector<CTransaction>::iterator it = block.vtx.begin(); it != block.vtx.end(); ++it)
+        {
+            LogPrintf("EraseTxIndex().\n");
+            txdb.EraseTxIndex(*it);
+        };
+        
+        LogPrintf("EraseBlockIndex().\n");
+        txdb.EraseBlockIndex(hashblock);
+        
+        errno = 0;
+        if (ftruncate(fileno(fp), fpos+foundPos-MESSAGE_START_SIZE) != 0)
+        {
+            LogPrintf("ftruncate failed: %s\n", strerror(errno));
+        };
+        
+        LogPrintf("hashBestChain %s, nBestHeight %d\n", hashBestChain.ToString().c_str(), nBestHeight);
+        
+        //fclose(fp); // ~CAutoFile() will close the file
+        nRemoved++;
+    };
+    }
+    
+    
+    result.push_back(Pair("no. blocks removed", itostr(nRemoved)));
+    
+    result.push_back(Pair("hashBestChain", hashBestChain.ToString()));
+    result.push_back(Pair("nBestHeight", itostr(nBestHeight)));
+    
+    // -- need restart, setStakeSeen etc
+    if (nRemoved > 0)
+        result.push_back(Pair("Please restart blackcoin", ""));
+    
+    if (nRemoved == nNumber)
+        result.push_back(Pair("result", "success"));
+    else
+        result.push_back(Pair("result", "failure"));
+    return result;
 }
 
 // ppcoin: get information of sync-checkpoint

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -117,6 +117,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getblock", 1 },
     { "getblockbynumber", 0 },
     { "getblockbynumber", 1 },
+    { "rewindchain", 0 }
     { "getblockhash", 0 },
     { "move", 2 },
     { "move", 3 },

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -117,7 +117,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getblock", 1 },
     { "getblockbynumber", 0 },
     { "getblockbynumber", 1 },
-    { "rewindchain", 0 }
+    { "rewindchain", 0 },
     { "getblockhash", 0 },
     { "move", 2 },
     { "move", 3 },

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -233,6 +233,7 @@ static const CRPCCommand vRPCCommands[] =
     { "getrawmempool",          &getrawmempool,          true,      false,     false },
     { "getblock",               &getblock,               false,     false,     false },
     { "getblockbynumber",       &getblockbynumber,       false,     false,     false },
+    { "rewindchain",            &rewindchain,            false,     false,     false }, 
     { "getblockhash",           &getblockhash,           false,     false,     false },
     { "getrawtransaction",      &getrawtransaction,      false,     false,     false },
     { "createrawtransaction",   &createrawtransaction,   false,     false,     false },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -175,6 +175,7 @@ extern json_spirit::Value getrawmempool(const json_spirit::Array& params, bool f
 extern json_spirit::Value getblockhash(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getblock(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getblockbynumber(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value rewindchain(const json_spirit::Array& params, bool fHelp); 
 extern json_spirit::Value getcheckpoint(const json_spirit::Array& params, bool fHelp);
 
 #endif

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -263,6 +263,11 @@ bool CTxDB::WriteBlockIndex(const CDiskBlockIndex& blockindex)
     return Write(make_pair(string("blockindex"), blockindex.GetBlockHash()), blockindex);
 }
 
+bool CTxDB::EraseBlockIndex(const uint256& blockhash)
+{
+    return Erase(make_pair(string("blockindex"), blockhash));
+}
+
 bool CTxDB::ReadHashBestChain(uint256& hashBestChain)
 {
     return Read(string("hashBestChain"), hashBestChain);
@@ -404,13 +409,21 @@ bool CTxDB::LoadBlockIndex()
     {
         CBlockIndex* pindex = item.second;
         vSortedByHeight.push_back(make_pair(pindex->nHeight, pindex));
-    }
+    };
     sort(vSortedByHeight.begin(), vSortedByHeight.end());
     BOOST_FOREACH(const PAIRTYPE(int, CBlockIndex*)& item, vSortedByHeight)
     {
         CBlockIndex* pindex = item.second;
+        
+        if (!pindex->pprev && pindex->GetBlockHash() != Params().HashGenesisBlock())
+        {
+            if (fDebug)
+                LogPrintf("LoadBlockIndex(): Warning - Found orphaned block, height %d, hash %s. Suggest rewindchain, reindex.\n", pindex->nHeight, pindex->GetBlockHash().ToString().c_str());
+            continue;
+        };
+
         pindex->nChainTrust = (pindex->pprev ? pindex->pprev->nChainTrust : 0) + pindex->GetBlockTrust();
-    }
+    };
 
     // Load hashBestChain pointer to end of best chain
     if (!ReadHashBestChain(hashBestChain))

--- a/src/txdb-leveldb.h
+++ b/src/txdb-leveldb.h
@@ -193,6 +193,7 @@ public:
     bool ReadDiskTx(COutPoint outpoint, CTransaction& tx, CTxIndex& txindex);
     bool ReadDiskTx(COutPoint outpoint, CTransaction& tx);
     bool WriteBlockIndex(const CDiskBlockIndex& blockindex);
+    bool EraseBlockIndex(const uint256& blockhash);
     bool ReadHashBestChain(uint256& hashBestChain);
     bool WriteHashBestChain(uint256 hashBestChain);
     bool ReadBestInvalidTrust(CBigNum& bnBestInvalidTrust);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -506,6 +506,24 @@ void ParseParameters(int argc, const char* const argv[])
     }
 }
 
+namespace bcblk
+{
+void* memrchr(const void *s, int c, size_t n)
+{
+    if (n < 1)
+        return NULL;
+
+    unsigned char* cp = (unsigned char*) s + n;
+
+    do {
+        if (*(--cp) == (unsigned char) c)
+            return (void*) cp;
+    } while (--n != 0);
+
+    return NULL;
+};
+}
+
 std::string GetArg(const std::string& strArg, const std::string& strDefault)
 {
     if (mapArgs.count(strArg))

--- a/src/util.h
+++ b/src/util.h
@@ -329,6 +329,11 @@ inline bool IsSwitchChar(char c)
 #endif
 }
 
+namespace bcblk
+{
+void* memrchr(const void *s, int c, size_t n);
+}
+
 /**
  * Return string argument or default value
  *


### PR DESCRIPTION
usage: rewindchain (number)
erases (number) of blocks from own blockchain file
taken from other coins. originally from shadowcash.